### PR TITLE
Return only 5 results & fix mention regex

### DIFF
--- a/bingus-bot/src/index.ts
+++ b/bingus-bot/src/index.ts
@@ -96,7 +96,7 @@ client.on("threadCreate", async (thread, newly) => {
 
     const embedList = new EmbedList();
     embedList.push(
-      ...data.map(
+      ...data.slice(0, 5).map(
         (res) =>
           new EmbedBuilder()
             .setTitle(res.title)
@@ -129,7 +129,7 @@ client.on("messageCreate", async (msg) => {
   await msg.fetch();
   const lowercase = msg.content.toLowerCase();
   // Check if Bingus is being mentioned in some way
-  if (msg.mentions.users.has(clientId) || /bot|bing\w{,4}/.test(lowercase)) {
+  if (msg.mentions.users.has(clientId) || /\b(bot|bing\w{0,4})\b/.test(lowercase)) {
     // Check if Bingus recently sent a message
     const lastMessages = await msg.channel.messages.fetch({
       limit: 10,

--- a/bingus-bot/src/util.ts
+++ b/bingus-bot/src/util.ts
@@ -18,7 +18,7 @@ import { fileURLToPath } from "url";
 export async function fetchBingus(query: string) {
   const url = `https://bingus.bscotch.ca/api/faq/search?question=${encodeURIComponent(
     query,
-  )}&responseCount=30`;
+  )}&responseCount=5`;
 
   return await fetch(url).then(
     (res) => res.json() as Promise<BingusFaqResponse[]>,


### PR DESCRIPTION
Fixed 30 results being requested when only 5 are used, and not trimming to 5 for support forum posts either.

From testing with https://regex101.com/ it doesn't look like any regex engine except Python likes `{,4}`, not totally sure if it's working currently but might as well just make it `{0,4}`. Also made the regex look for word boundaries, so it doesn't get triggered by "both" or anything like that anymore.